### PR TITLE
fix: exit if no python

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -6,6 +6,7 @@ PYTHON=$(python --version)
 
 if ! [[ "$PYTHON" == Python* ]]; then
   echo "Make sure python is installed"
+  exit 1
 fi
 echo "Checking commit message now!"
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -6,6 +6,7 @@ PYTHON=$(python --version)
 
 if ! [[ "$PYTHON" == Python* ]]; then
   echo "Make sure python is installed"
+  exit 1
 fi
 
 if ! [[ $(where pylint) == *\pylint* ]]; then


### PR DESCRIPTION
Hook exits with 1 if no python is installed